### PR TITLE
Enabling use of P9_41 as gpio.

### DIFF
--- a/src/arm/am335x-bone-common-no-capemgr.dtsi
+++ b/src/arm/am335x-bone-common-no-capemgr.dtsi
@@ -92,12 +92,6 @@
 		>;
 	};
 
-	clkout2_pin: pinmux_clkout2_pin {
-		pinctrl-single,pins = <
-			0x1b4 (PIN_OUTPUT_PULLDOWN | MUX_MODE3)	/* xdma_event_intr1.clkout2 */
-		>;
-	};
-
 	cpsw_default: cpsw_default {
 		pinctrl-single,pins = <
 			/* Slave 1 */

--- a/src/arm/am335x-bone-common.dtsi
+++ b/src/arm/am335x-bone-common.dtsi
@@ -62,9 +62,6 @@
 };
 
 &am33xx_pinmux {
-	pinctrl-names = "default";
-	pinctrl-0 = <&clkout2_pin>;
-
 	user_leds_s0: user_leds_s0 {
 		pinctrl-single,pins = <
 			0x54 (PIN_OUTPUT_PULLDOWN | MUX_MODE7)	/* gpmc_a5.gpio1_21 */
@@ -92,12 +89,6 @@
 		pinctrl-single,pins = <
 			0x170 (PIN_INPUT_PULLUP | MUX_MODE0)	/* uart0_rxd.uart0_rxd */
 			0x174 (PIN_OUTPUT_PULLDOWN | MUX_MODE0)	/* uart0_txd.uart0_txd */
-		>;
-	};
-
-	clkout2_pin: pinmux_clkout2_pin {
-		pinctrl-single,pins = <
-			0x1b4 (PIN_OUTPUT_PULLDOWN | MUX_MODE3)	/* xdma_event_intr1.clkout2 */
 		>;
 	};
 

--- a/src/arm/am335x-boneblack-bbb-exp-r.dts
+++ b/src/arm/am335x-boneblack-bbb-exp-r.dts
@@ -25,11 +25,6 @@
 	vmmc-supply = <&vmmcsd_fixed>;
 };
 
-&am33xx_pinmux {
-	pinctrl-names = "default";
-	pinctrl-0 = <&clkout2_pin>;
-};
-
 #include "am335x-peripheral-emmc.dtsi"
 #include "am335x-bone-pinmux-emmc.dtsi"
 /* #include "am335x-bone-emmc-in-reset.dtsi" */

--- a/src/arm/am335x-boneblack-replicape.dts
+++ b/src/arm/am335x-boneblack-replicape.dts
@@ -35,9 +35,6 @@
 };
 
 &am33xx_pinmux {
-	pinctrl-names = "default";
-	pinctrl-0 = <&clkout2_pin>;
-
 	nxp_hdmi_bonelt_pins: nxp_hdmi_bonelt_pins {
 		pinctrl-single,pins = <
 			0x1b0 0x03      /* xdma_event_intr0, OMAP_MUX_MODE3 | AM33XX_PIN_OUTPUT */
@@ -68,13 +65,6 @@
 			0x1b0 0x03      /* xdma_event_intr0, OMAP_MUX_MODE3 | AM33XX_PIN_OUTPUT */
 		>;
 	};
-
-	clkout2_pin: pinmux_clkout2_pin {
-		pinctrl-single,pins = <
-			0x1b4 (PIN_OUTPUT_PULLDOWN | MUX_MODE7)	/* xdma_event_intr1.clkout2 */
-		>;
-	};
-
 };
 
 &lcdc {


### PR DESCRIPTION
Based on https://github.com/RobertCNelson/dtb-rebuilder/commit/f93ae3ebb242562ceffad37fd2b60a99e0f374ff
