### PR TITLE
am335x-boneblack-wireless-roboticscape: use correct model name

### DIFF
--- a/src/arm/am335x-boneblack-wireless-roboticscape.dts
+++ b/src/arm/am335x-boneblack-wireless-roboticscape.dts
@@ -23,7 +23,7 @@
 #include "am335x-roboticscape.dtsi"
 
 / {
-	model = "TI AM335x BeagleBone Black Wireless RoboticsCape";
+	model = "TI AM335x BeagleBone Black Wireless";
 	compatible = "ti,am335x-bone-black", "ti,am335x-bone", "ti,am33xx";
 };
 


### PR DESCRIPTION
I believe you want to keep the existing model name to make the scripts work. Capes should not change the base model name.