### PR TITLE
Add pinmux helper for A15 pin

### DIFF
--- a/src/arm/am335x-bone-common-univ.dtsi
+++ b/src/arm/am335x-bone-common-univ.dtsi
@@ -1183,6 +1183,18 @@
 	/* P9_45                GND */
 
 	/* P9_46                GND */
+
+	/*       (ZCZ ball A15) */
+	A15_default_pin: pinmux_A15_default_pin {
+		pinctrl-single,pins = <0x1b0  0x0b>; };     /* Mode 3 */
+	A15_clkout_pin: pinmux_A15_clkout_pin {
+		pinctrl-single,pins = <0x1b0  0x0b>; };     /* Mode 3 */
+	A15_gpio_pin: pinmux_A15_gpio_pin {
+		pinctrl-single,pins = <0x1b0  0x2f>; };     /* Mode 7, RxActive */
+	A15_gpio_pu_pin: pinmux_A15_gpio_pu_pin {
+		pinctrl-single,pins = <0x1b0  0x37>; };     /* Mode 7, Pull-Up, RxActive */
+	A15_gpio_pd_pin: pinmux_A15_gpio_pd_pin {
+		pinctrl-single,pins = <0x1b0  0x27>; };     /* Mode 7, Pull-Down, RxActive */
 };
 
 &i2c1 {
@@ -2425,6 +2437,17 @@
 
 	/* P9_46                GND */
 
+	/*       (ZCZ ball A15) */
+	A15_pinmux {
+		compatible = "bone-pinmux-helper";
+		status = "okay";
+		pinctrl-names = "default", "clkout", "gpio", "gpio_pu", "gpio_pd";
+		pinctrl-0 = <&A15_default_pin>;
+		pinctrl-1 = <&A15_clkout_pin>;
+		pinctrl-2 = <&A15_gpio_pin>;
+		pinctrl-3 = <&A15_gpio_pu_pin>;
+		pinctrl-4 = <&A15_gpio_pd_pin>;
+	};
 
 	cape-universal {
 		compatible = "gpio-of-helper";
@@ -2915,5 +2938,11 @@
 			dir-changeable;
 		};
 
+		A15 {
+			gpio-name = "A15";
+			gpio = <&gpio0 19 0>;
+			input;
+			dir-changeable;
+		};
 	};
 };

--- a/src/arm/am335x-bone-common-universal-pins.dtsi
+++ b/src/arm/am335x-bone-common-universal-pins.dtsi
@@ -952,4 +952,16 @@
 	/* P9_44                GND     */
 	/* P9_45                GND     */
 	/* P9_46                GND     */
+
+	/*       (ZCZ ball A15) */
+	A15_default_pin: pinmux_A15_default_pin {
+		pinctrl-single,pins = <0x1b0  0x0b>; };     /* Mode 3 */
+	A15_clkout_pin: pinmux_A15_clkout_pin {
+		pinctrl-single,pins = <0x1b0  0x0b>; };     /* Mode 3 */
+	A15_gpio_pin: pinmux_A15_gpio_pin {
+		pinctrl-single,pins = <0x1b0  0x2f>; };     /* Mode 7, RxActive */
+	A15_gpio_pu_pin: pinmux_A15_gpio_pu_pin {
+		pinctrl-single,pins = <0x1b0  0x37>; };     /* Mode 7, Pull-Up, RxActive */
+	A15_gpio_pd_pin: pinmux_A15_gpio_pd_pin {
+		pinctrl-single,pins = <0x1b0  0x27>; };     /* Mode 7, Pull-Down, RxActive */
 };


### PR DESCRIPTION
By default, this provides a clock used for CEC by the HDMI framer,
but there is an internal clock and almost no one uses CEC. A lot of
EMC noise is made if this signal is left on, so it should be turned
off. This provides the ability to turn it off.